### PR TITLE
Configure HTTP Basic Authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [joda-time/joda-time "2.10.13"]
                  [commons-io/commons-io "2.11.0"]
                  [compojure "1.6.2"]
+                 [ring-basic-authentication "1.2.0"]
                  [ring/ring-core "1.9.4"]
                  [ring/ring-jetty-adapter "1.9.4"]
                  [ring/ring-defaults "0.3.3"]

--- a/src/mini_file_server/core/handler.clj
+++ b/src/mini_file_server/core/handler.clj
@@ -34,13 +34,11 @@
       (content-type "application/x-compressed")))
 
 (def mfs-auth
-  (let [mfs-auth (System/getenv "MFS_AUTH")]
-       (if mfs-auth
-         (str/split mfs-auth #":"))))
+  (some-> (System/getenv "MFS_AUTH")
+          (str/split #":")))
 
 (defn authenticated? [id pass]
-  (and (= id (nth mfs-auth 0))
-       (= pass (nth mfs-auth 1))))
+  (= [id pass] mfs-auth))
 
 (defroutes update-routes
   (POST "/" {{{:keys [tempfile filename]} :file group :group} :params :as params}

--- a/src/mini_file_server/core/handler.clj
+++ b/src/mini_file_server/core/handler.clj
@@ -53,10 +53,10 @@
     (response {:result
                (and (some? new-name)
                     (apply fs/rename (map fs/path-for [old-name new-name])))}))
-(DELETE "/*" {{filename :*} :params}
-  (let [path (fs/path-for filename)]
-    (log/info (format "Deleting %s: %s" filename path))
-    (response {:result (fs/delete path)}))))
+  (DELETE "/*" {{filename :*} :params}
+    (let [path (fs/path-for filename)]
+      (log/info (format "Deleting %s: %s" filename path))
+      (response {:result (fs/delete path)}))))
 
 (defroutes app-routes
   (route/resources "/")

--- a/src/mini_file_server/core/handler.clj
+++ b/src/mini_file_server/core/handler.clj
@@ -35,8 +35,7 @@
 
 (defn authenticated? [id pass]
   (and (= id "admin")
-       (= pass "admin")
-       {:user id :passwd pass}))
+       (= pass "admin")))
 
 (defroutes update-routes
   (POST "/" {{{:keys [tempfile filename]} :file group :group} :params :as params}


### PR DESCRIPTION
Configure POST,PUT,DELETE routes as update-routes with basic-auth 

Current major limitation:
 - Auth is not optional.
 - Users are not configurable. (Hardcoded as admin/admin)